### PR TITLE
Upgrade Kotlin, KSP, Compose and others

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,7 @@ android {
 
     composeOptions {
         // Keep in sync with Kotlin version: https://developer.android.com/jetpack/androidx/releases/compose-kotlin
-        kotlinCompilerExtensionVersion = "1.5.4"
+        kotlinCompilerExtensionVersion = "1.5.8"
     }
 
     flavorDimensions += "distribution"
@@ -105,9 +105,9 @@ configurations {
 
 dependencies {
     val aboutLibsVersion: String by rootProject.extra
-    val composeBomVersion = "2023.08.00"   // https://developer.android.com/jetpack/compose/bom
+    val composeBomVersion = "2023.10.01"   // https://developer.android.com/jetpack/compose/bom
     val okhttp = "5.0.0-alpha.11"
-    val room = "2.6.0"
+    val room = "2.6.1"
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
@@ -115,16 +115,16 @@ dependencies {
     implementation("com.github.bitfireAT:cert4android:3817e62d9f173d8f8b800d24769f42cb205f560e")
     implementation("com.github.bitfireAT:ical4android:916f2228e8fb55d26dea171733feaf22d6e45594")
 
-    implementation("androidx.activity:activity-compose:1.8.1")
+    implementation("androidx.activity:activity-compose:1.8.2")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.cardview:cardview:1.0.0")
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.fragment:fragment-ktx:1.6.2")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
-    implementation("androidx.work:work-runtime-ktx:2.8.1")
-    implementation("com.google.android.material:material:1.10.0")
+    implementation("androidx.work:work-runtime-ktx:2.9.0")
+    implementation("com.google.android.material:material:1.11.0")
 
     // Jetpack Compose
     val composeBom = platform("androidx.compose:compose-bom:${composeBomVersion}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 buildscript {
     val aboutLibsVersion by extra("10.7.0")
     val agpVersion = "8.1.4"
-    val kotlinVersion = "1.9.20"
-    val kspVersion = "1.0.14"
+    val kotlinVersion = "1.9.22"
+    val kspVersion = "1.0.16"
 
     repositories {
         google()


### PR DESCRIPTION
### Upgrades

| Library | From | To
|---|:-:|:-:|
| Kotlin | `1.9.20` | `1.9.22` |
| KSP | `1.0.14` | `1.0.16` |
| Compose Compiler | `1.5.4` | `1.5.8` |
| Compose BOM | `2023.08.00` | `2023.10.01` |
| Room | `2.6.0` | `2.6.1` |
| `androidx.activity:activity-compose` | `1.8.1` | `1.8.2` |
| `androidx.lifecycle:lifecycle-viewmodel-ktx` | `2.6.2` | `2.7.0` |
| `androidx.work:work-runtime-ktx` | `2.8.1` | `2.9.0` |
| `com.google.android.material:material` | `1.10.0` | `1.11.0` |