### PR TITLE
Added missing line break

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -51,4 +51,5 @@ jobs:
           # (Optional) A custom comment body. It supports `{{ dependencies }}` token.
           comment: >
             This PR/issue depends on:
+            
             {{ dependencies }}


### PR DESCRIPTION
Comments were not correctly formatted because a line break was missing.