### PR TITLE
Using BOM for OkHttp and downgrade to stable

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -146,7 +146,8 @@ dependencies {
     androidTestImplementation(okHttpBom)
     implementation("com.squareup.okhttp3:okhttp")
     implementation("com.squareup.okhttp3:okhttp-brotli")
-    implementation("com.squareup.okhttp3:okhttp-coroutines")
+    // FIXME - Add when OkHttp 5.0.0 is stable
+    // implementation("com.squareup.okhttp3:okhttp-coroutines")
 
     // latest commons that don"t require Java 8
     //noinspection GradleDependency

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -106,7 +106,6 @@ configurations {
 dependencies {
     val aboutLibsVersion: String by rootProject.extra
     val composeBomVersion = "2023.10.01"   // https://developer.android.com/jetpack/compose/bom
-    val okhttp = "5.0.0-alpha.11"
     val room = "2.6.1"
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
@@ -140,10 +139,14 @@ dependencies {
 
     implementation("com.jaredrummler:colorpicker:1.1.0")
     implementation("com.mikepenz:aboutlibraries-compose:${aboutLibsVersion}")
-    implementation("com.squareup.okhttp3:okhttp:${okhttp}")
-    implementation("com.squareup.okhttp3:okhttp-brotli:${okhttp}")
-    implementation("com.squareup.okhttp3:okhttp-coroutines:${okhttp}")
     implementation("joda-time:joda-time:2.12.6")
+
+    val okHttpBom = platform("com.squareup.okhttp3:okhttp-bom:4.12.0")
+    implementation(okHttpBom)
+    androidTestImplementation(okHttpBom)
+    implementation("com.squareup.okhttp3:okhttp")
+    implementation("com.squareup.okhttp3:okhttp-brotli")
+    implementation("com.squareup.okhttp3:okhttp-coroutines")
 
     // latest commons that don"t require Java 8
     //noinspection GradleDependency
@@ -160,7 +163,7 @@ dependencies {
     androidTestImplementation("androidx.test:rules:1.5.0")
     androidTestImplementation("androidx.arch.core:core-testing:2.2.0")
     androidTestImplementation("junit:junit:4.13.2")
-    androidTestImplementation("com.squareup.okhttp3:mockwebserver:${okhttp}")
+    androidTestImplementation("com.squareup.okhttp3:mockwebserver")
     androidTestImplementation("androidx.work:work-testing:2.9.0")
 
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/java/at/bitfire/icsdroid/AsyncUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/AsyncUtils.kt
@@ -1,0 +1,30 @@
+package at.bitfire.icsdroid
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Response
+import okio.IOException
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Executes the call suspendfully.
+ *
+ * FIXME - Should be removed and replaced with the official function when 5.0.0 stable is released.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+suspend fun Call.executeAsync(): Response = suspendCancellableCoroutine { continuation ->
+    continuation.invokeOnCancellation {
+        this.cancel()
+    }
+    this.enqueue(object : Callback {
+        override fun onFailure(call: Call, e: IOException) {
+            continuation.resumeWithException(e)
+        }
+
+        override fun onResponse(call: Call, response: Response) {
+            continuation.resume(value = response, onCancellation = { call.cancel() })
+        }
+    })
+}

--- a/app/src/main/java/at/bitfire/icsdroid/AsyncUtils.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/AsyncUtils.kt
@@ -12,6 +12,8 @@ import kotlin.coroutines.resumeWithException
  * Executes the call suspendfully.
  *
  * FIXME - Should be removed and replaced with the official function when 5.0.0 stable is released.
+ *
+ * @see <a href="https://github.com/square/okhttp/blob/parent-5.0.0-alpha.12/okhttp-coroutines/src/jvmMain/kotlin/okhttp3/JvmCallExtensions.kt">Source</a>
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 suspend fun Call.executeAsync(): Response = suspendCancellableCoroutine { continuation ->

--- a/app/src/main/java/at/bitfire/icsdroid/CalendarFetcher.kt
+++ b/app/src/main/java/at/bitfire/icsdroid/CalendarFetcher.kt
@@ -13,7 +13,6 @@ import at.bitfire.icsdroid.HttpUtils.toUri
 import okhttp3.Credentials
 import okhttp3.MediaType
 import okhttp3.Request
-import okhttp3.executeAsync
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.InputStream
@@ -155,8 +154,8 @@ open class CalendarFetcher(
                     // 20x
                     response.isSuccessful ->
                         onSuccess(
-                                response.body.byteStream(),
-                                response.body.contentType(),
+                                response.body!!.byteStream(),
+                                response.body!!.contentType(),
                                 response.header("ETag"),
                                 response.header("Last-Modified")?.let {
                                     HttpUtils.parseDate(it)?.time


### PR DESCRIPTION
Downgrades to stable 4.12.0

Since coroutines are not available until 5.0.0, added the `executeAsync` function from the package until the stable version is released. [See source](https://github.com/square/okhttp/blob/parent-5.0.0-alpha.12/okhttp-coroutines/src/jvmMain/kotlin/okhttp3/JvmCallExtensions.kt)